### PR TITLE
Fix tcc reset, force install, ask user for screen recording

### DIFF
--- a/office_reset_tools/mofa_community_maintained/scripts/MOFA_Community_Microsoft_Teams_Reset.zsh
+++ b/office_reset_tools/mofa_community_maintained/scripts/MOFA_Community_Microsoft_Teams_Reset.zsh
@@ -74,7 +74,7 @@ runAsUser() {
 
 open_systempreferences() {
     local preferenceID="$1"
-    printlog "open url: x-apple.systempreferences:${preferenceID}"
+    echo "open url: x-apple.systempreferences:${preferenceID}"
 	su - $LoggedInUser -c "open -u \"x-apple.systempreferences:${preferenceID}\" 2>/dev/null"
 }
 


### PR DESCRIPTION
1.0.2:

Additions to use `shellcheck`, define `PATH`, and preserve Teams backgrounds. Classic Teams is dead.

Addition to read arguments with variables (`INSTALL=force` will always removed installed version), reset TCC. Open window for user to allow Screen recording after TCC reset.

Anyone experiencing this problem: https://answers.microsoft.com/en-us/msteams/forum/all/why-is-teams-screen-share-not-working-after-i/54f342f9-71b7-428f-bc0c-4e8e8205a81d

Can now run this script with `INSTALL=force` with this instruction:
Let screen recording be disabled, start Teams, then enable screen recording (and restart Teams).